### PR TITLE
<fix> corrupting the plugin file system

### DIFF
--- a/freemarker-wrapper/pom.xml
+++ b/freemarker-wrapper/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>freemarker-wrapper</artifactId>
     <groupId>io.codeontap</groupId>
-    <version>1.11</version>
+    <version>1.11.1</version>
     <build>
         <plugins>
             <plugin>

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/LayerProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/LayerProcessor.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultMapAdapter;
 import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
 import io.codeontap.freemarkerwrapper.files.FileFinder;
 import io.codeontap.freemarkerwrapper.files.layers.Layer;
 import io.codeontap.freemarkerwrapper.RunFreeMarkerException;
@@ -27,6 +28,8 @@ public abstract class LayerProcessor {
     protected Map<String, Layer> layerMap = new LinkedHashMap<>();
     private Map<String, List<Path>> filesPerLayer = new LinkedHashMap<>();
     protected Configuration configuration;
+    protected String fileSystemShareVariableName;
+    protected String layerMapShareVariableName;
 
     public abstract void createLayerFileSystem(LayerMeta meta) throws RunFreeMarkerException;
     public abstract void postProcessMeta(LayerMeta meta);
@@ -50,6 +53,15 @@ public abstract class LayerProcessor {
         createLayerFileSystem(meta);
     }
 
+    protected void setSharedVariables(){
+        try {
+            configuration.setSharedVariable(fileSystemShareVariableName, fileSystem);
+            configuration.setSharedVariable(layerMapShareVariableName, layerMap);
+        } catch (TemplateModelException e) {
+            e.printStackTrace();
+        }
+    }
+
     public Set<JsonObject> getLayerTree(LayerMeta meta) throws RunFreeMarkerException{
         Set<JsonObject> output = new LinkedHashSet<>();
 
@@ -57,12 +69,12 @@ public abstract class LayerProcessor {
             meta.setStartingPath("/".concat(meta.getStartingPath()));
         }
 
-        if (configuration.getSharedVariableNames().contains("fileSystem")){
-            fileSystem = (TreeMap)((DefaultMapAdapter)configuration.getSharedVariable("fileSystem")).getWrappedObject();
+        if (configuration.getSharedVariableNames().contains(fileSystemShareVariableName)){
+            fileSystem = (TreeMap)((DefaultMapAdapter)configuration.getSharedVariable(fileSystemShareVariableName)).getWrappedObject();
         }
 
-        if (configuration.getSharedVariableNames().contains("layerMap")){
-            layerMap = (LinkedHashMap)((DefaultMapAdapter)configuration.getSharedVariable("layerMap")).getWrappedObject();
+        if (configuration.getSharedVariableNames().contains(layerMapShareVariableName)){
+            layerMap = (LinkedHashMap)((DefaultMapAdapter)configuration.getSharedVariable(layerMapShareVariableName)).getWrappedObject();
         }
 
         if(fileSystem == null){

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/cmdb/CMDBProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/cmdb/CMDBProcessor.java
@@ -164,12 +164,9 @@ public class CMDBProcessor extends LayerProcessor {
         fileSystem = processCMDBFileSystem(cmdbMeta.getBaseCMDB(), buildCMDBFileSystem(
                 cmdbMeta.getBaseCMDB(), cmdbMeta.getCMDBs(), cmdbMeta.isUseCMDBPrefix(), cmdbMeta.getLayersNames(), true));
 
-        try {
-            configuration.setSharedVariable("fileSystem", fileSystem);
-            configuration.setSharedVariable("layerMap", layerMap);
-        } catch (TemplateModelException e) {
-            e.printStackTrace();
-        }
+        fileSystemShareVariableName = "cmdbFileSystem";
+        layerMapShareVariableName = "cmdbLayerMap";
+        setSharedVariables();
     }
 
     @Override

--- a/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/plugin/PluginProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/codeontap/freemarkerwrapper/files/processors/plugin/PluginProcessor.java
@@ -32,12 +32,9 @@ public class PluginProcessor extends LayerProcessor {
             }
         }
 
-        try {
-            configuration.setSharedVariable("fileSystem", fileSystem);
-            configuration.setSharedVariable("layerMap", layerMap);
-        } catch (TemplateModelException e) {
-            e.printStackTrace();
-        }
+        fileSystemShareVariableName = "pluginFileSystem";
+        layerMapShareVariableName = "pluginLayerMap";
+        setSharedVariables();
     }
 
     @Override

--- a/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
+++ b/freemarker-wrapper/src/test/java/io/codeontap/freemarkerwrapper/GetCMDBTreeMethodTest.java
@@ -198,6 +198,77 @@ public class GetCMDBTreeMethodTest {
     }
 
     @Test
+    public void getPluginTreeAfterCMDBInit() throws IOException, TemplateException{
+
+        input = new HashMap<String, Object>();
+        input.put("getFileTree", new GetCMDBTreeMethod());
+        input.put("initialiseCMDBFileSystem", new InitCMDBsMethod());
+        input.put("initialisePluginFileSystem", new InitPluginsMethod());
+        String fileName = templatesPath.concat("/file.ftl");
+        Files.write(Paths.get(fileName), (String.format(getFileTreeAccountsTemplateMatchOptions, false, false, false, false)).getBytes());
+        String content = getCMDBsAccountsTemplate;
+        createFile(cmdbsPath,"accounts/path/1/test", "test.json", content);
+        createFile(cmdbsPath,"api/path/2/match", "test.json", "{}");
+        createFile(cmdbsPath,"almv2/path/3/test", "match", "[#ftl]");
+        createFile(cmdbsPath,"almv2/path/3/test/subdir", "match", "[#ftl]");
+        createFile(cmdbsPath,"accounts", ".cmdb", content);
+        createFile(cmdbsPath,"api", ".cmdb", "{}");
+        createFile(cmdbsPath,"almv2", ".cmdb", "{}");
+        Map<String,String> cmdbPathMapping = new HashMap();
+        input.put("cmdbPathMappings", cmdbPathMapping);
+        input.put("lookupDirs", Arrays.asList(new String[]{cmdbsPath}));
+        input.put("CMDBNames", Arrays.asList(new String[]{ "accounts", "almv2", "api"  }));
+        input.put("baseCMDB", "accounts");
+        cfg.setTemplateLoader(new FileTemplateLoader(new File("/")));
+        Template freeMarkerTemplate = cfg.getTemplate(fileName);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        Writer consoleWriter = new OutputStreamWriter(byteArrayOutputStream);
+
+        Environment env = freeMarkerTemplate.createProcessingEnvironment(input, consoleWriter);
+        freeMarkerTemplate.process(input, consoleWriter);
+
+
+        input.put("getPluginTree", new GetPluginTreeMethod());
+
+        String fileName2 = templatesPath.concat("/file2.ftl");
+        Files.write(Paths.get(fileName2), (String.format(getEngineTemplate, "test.json")).getBytes());
+
+        createFile(pluginsPath,"test/aws", "test.JSON", "{}");
+        createFile(pluginsPath,"test/azure", "test.json", "{}");
+        createFile(pluginsPath,"test/test", "test-1.json", "{}");
+
+        input.put("pluginLayers", Arrays.asList(new String[]{
+                pluginsPath.concat("/test/aws"),
+                pluginsPath.concat("/test/azure"),
+                pluginsPath.concat("/test/test")
+        }));
+
+        cfg.setTemplateLoader(new FileTemplateLoader(new File("/")));
+        Template freeMarkerTemplate2 = cfg.getTemplate(fileName2);
+        ByteArrayOutputStream byteArrayOutputStream2 = new ByteArrayOutputStream();
+        Writer consoleWriter2 = new OutputStreamWriter(byteArrayOutputStream2);
+        freeMarkerTemplate2.process(input, consoleWriter2);
+        String output = new String(byteArrayOutputStream2.toByteArray());
+        Pattern p = Pattern.compile("Name : aws");
+        Matcher m = p.matcher(output);
+        int count = 0;
+        while (m.find())
+            count++;
+        Assert.assertEquals(1, count);
+        p = Pattern.compile("ContentsAsJSON : #hash#");
+        m = p.matcher(output);
+        count = 0;
+        while (m.find())
+            count++;
+        Assert.assertEquals(1, count);
+        System.out.println("--------------------------- OUTPUT ---------------------------");
+        System.out.write(output.getBytes());
+
+    }
+
+
+    @Test
     public void getPluginTreeYaml() throws IOException, TemplateException{
         input = new HashMap<String, Object>();
         input.put("getPluginTree", new GetPluginTreeMethod());


### PR DESCRIPTION
Fix for CMDB Initialisation corrupting the plugin file system

## Description
<!--- Describe your changes in detail -->
Plugin and CMDB processors used to have the same name for shared variables to keep the information about the initialised filesystem and layers map. This was causing the corruption described in #33  - initialisation of a CMDBs tree affected the already initialised plugin tree and vice versa.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for #33
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added to cover the scenario described in the #33
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] None of the above.
