### PR TITLE
fix: adjust rmCMDB logic to remove a specified file

### DIFF
--- a/freemarker-wrapper/pom.xml
+++ b/freemarker-wrapper/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>freemarker-wrapper</artifactId>
     <groupId>io.hamlet</groupId>
-    <version>1.14.0</version>
+    <version>1.14.1-rc1</version>
     <build>
         <plugins>
             <plugin>

--- a/freemarker-wrapper/pom.xml
+++ b/freemarker-wrapper/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>freemarker-wrapper</artifactId>
     <groupId>io.hamlet</groupId>
-    <version>1.14.1-rc1</version>
+    <version>1.14.1</version>
     <build>
         <plugins>
             <plugin>

--- a/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/files/processors/layer/cmdb/CMDBProcessor.java
+++ b/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/files/processors/layer/cmdb/CMDBProcessor.java
@@ -240,6 +240,7 @@ public class CMDBProcessor extends LayerProcessor {
                 } else return 1;
             }
         } else {
+            cmdbMeta.setMaxDepth(1);
             String sourceStartingPath = StringUtils.substringBeforeLast(cmdbMeta.getToPath(), "/");
             String sourceFilenameGlob = StringUtils.substringAfterLast(cmdbMeta.getToPath(), "/");
             cmdbMeta.setStartingPath(sourceStartingPath);

--- a/freemarker-wrapper/src/test/java/io/hamlet/freemarkerwrapper/GetCMDBTreeMethodTest.java
+++ b/freemarker-wrapper/src/test/java/io/hamlet/freemarkerwrapper/GetCMDBTreeMethodTest.java
@@ -27,10 +27,7 @@ import org.junit.Test;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -323,6 +320,40 @@ public class GetCMDBTreeMethodTest {
             "    }\n" +
             "  ) ]\n" +
             "\n";
+    private final String cpRmTemplate = "[#ftl]\n" +
+            "[#include \"/base.ftl\"]\n" +
+            "[\n" +
+            "[#assign copy =\n" +
+            "    cpCMDB(\n" +
+            "        \"/default/cic/state/cf/integration/default/seg-cert-pmenp01-ap-southeast-2-epilogue-pseduo-stack.json\",\n" +
+            "        \"/default/cic/state/cf/integration/default/cert/default/seg-cert-pmenp01-ap-southeast-2-epilogue-pseduo-stack.json\",\n" +
+            "        {\n" +
+            "            \"Recurse\" : false,\n" +
+            "            \"Preserve\" : true\n" +
+            "        }\n" +
+            "    )\n" +
+            "]\n" +
+            "[@toJSON\n" +
+            "    {\n" +
+            "        \"Copy\" : copy\n" +
+            "    }\n" +
+            "/]\n" +
+            "[#assign delete =\n" +
+            "    rmCMDB(\n" +
+            "        \"/default/cic/state/cf/integration/default/seg-cert-pmenp01-ap-southeast-2-epilogue-pseduo-stack.json\",\n" +
+            "        {\n" +
+            "            \"Recurse\" : false,\n" +
+            "            \"Force\" : false\n" +
+            "        }\n" +
+            "    )\n" +
+            "]\n" +
+            ",[@toJSON\n" +
+            "    {\n" +
+            "        \"Delete\" : delete\n" +
+            "    }\n" +
+            "/]\n" +
+            "]";
+
     private final String rmTemplate = "[#ftl]\n" +
             "\n" +
             "[#assign candidates =\n" +
@@ -1958,6 +1989,7 @@ public class GetCMDBTreeMethodTest {
         createFile(cmdbsPath, "accounts/products/almv2-copy", "temp.json", "{}");
         createFile(cmdbsPath, "api", "test.json", "{}");
         createFile(cmdbsPath, "almv2/dir", "test.json", "{}");
+        createFile(cmdbsPath, "almv2/dir/cic/default", "test.json", "{}");
         createFile(cmdbsPath, "almv2/dir", "test-1.json", "{}");
         createFile(cmdbsPath, "almv2/dir", "test-2.json", "{}");
         createFile(cmdbsPath, "api/another-dir", "test.json", "{}");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implicitly set a maxDepth to 1 for rmCMDB when a file is being removed.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When rmCMDB receives is called with a path pointing to a file to be removed, it looks for it on the filesystem. In order to force it to use the specified path and don't check sub-directories, we set maxDepth parameter for a file lookup to 1.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] None of the above.
