### PR TITLE
feat: Target platforms for bundled build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target
 *.iml
 .hamlet/
+
+build/
+.gradle

--- a/freemarker-wrapper/build.gradle
+++ b/freemarker-wrapper/build.gradle
@@ -44,6 +44,8 @@ description = 'freemarker-wrapper'
 runtime {
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
 
+    modules = ['java.desktop', 'java.rmi', 'java.sql', 'java.logging', 'java.xml', 'java.naming', 'java.compiler', 'java.scripting', 'java.management']
+
     targetPlatform("win") {
         jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.13_8.zip")
     }

--- a/freemarker-wrapper/build.gradle
+++ b/freemarker-wrapper/build.gradle
@@ -69,7 +69,9 @@ runtime {
 
 jar {
     manifest {
-        attributes 'Main-Class': 'io.hamlet.freemarkerwrapper.RunFreeMarker'
+        attributes (
+            'Main-Class': 'io.hamlet.freemarkerwrapper.RunFreeMarker',
+            'Multi-Release': true)
     }
 }
 

--- a/freemarker-wrapper/build.gradle
+++ b/freemarker-wrapper/build.gradle
@@ -40,7 +40,6 @@ test {
 group = 'io.hamlet'
 version = '2.0.0'
 description = 'freemarker-wrapper'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 publishing {
     publications {
@@ -51,28 +50,41 @@ publishing {
 }
 
 runtime {
-    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+    options = [
+        '--strip-debug',
+        '--compress', '2',
+        '--no-header-files',
+        '--no-man-pages'
+    ]
 
-    modules = ['java.desktop', 'java.rmi', 'java.sql', 'java.logging', 'java.xml', 'java.naming', 'java.compiler', 'java.scripting', 'java.management']
+    modules = [
+        'java.desktop',
+        'java.rmi',
+        'java.sql',
+        'java.logging',
+        'java.xml',
+        'java.naming',
+        'java.compiler',
+        'java.scripting',
+        'java.management'
+    ]
 
-    targetPlatform("win") {
-        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.13_8.zip")
+    targetPlatform("Windows") {
+        jdkHome = jdkDownload(
+            "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.13_8.zip"
+        )
     }
 
-    targetPlatform("lin") {
-        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz") {
-            archiveExtension = "tar.gz"
-            pathToHome = "jdk-11.0.13+8"
-            overwrite = true
-        }
+    targetPlatform("Linux") {
+        jdkHome = jdkDownload(
+            "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz"
+        )
     }
 
-    targetPlatform("mac") {
-        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.13_8.tar.gz") {
-            archiveExtension = "tar.gz"
-            pathToHome = "jdk-11.0.13+8/Contents/Home"
-            overwrite = true
-        }
+    targetPlatform("Darwin") {
+        jdkHome = jdkDownload(
+            "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.13_8.tar.gz"
+        )
     }
 }
 
@@ -80,7 +92,8 @@ jar {
     manifest {
         attributes (
             'Main-Class': 'io.hamlet.freemarkerwrapper.RunFreeMarker',
-            'Multi-Release': true)
+            'Multi-Release': true
+        )
     }
 }
 

--- a/freemarker-wrapper/build.gradle
+++ b/freemarker-wrapper/build.gradle
@@ -40,6 +40,15 @@ test {
 group = 'io.hamlet'
 version = '2.0.0'
 description = 'freemarker-wrapper'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+}
 
 runtime {
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']

--- a/freemarker-wrapper/build.gradle
+++ b/freemarker-wrapper/build.gradle
@@ -5,7 +5,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id "org.beryx.runtime" version "1.3.0"
+    id 'org.beryx.runtime' version '1.12.7'
 }
 
 repositories {
@@ -16,24 +16,24 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.freemarker:freemarker:2.3.31'
     implementation 'com.github.seancfoley:ipaddress:5.3.3'
-    implementation 'commons-cli:commons-cli:1.4'
+    implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'javax.json:javax.json-api:1.1.4'
     implementation 'org.glassfish:javax.json:1.1.4'
-    implementation 'commons-io:commons-io:2.9.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
-    implementation 'org.apache.logging.log4j:log4j-api:2.13.3'
-    implementation 'org.apache.logging.log4j:log4j-core:2.13.3'
+    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
+
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0-M1'
 }
 
 test {
     useJUnit()
-
     maxHeapSize = '1G'
 }
 
@@ -43,6 +43,26 @@ description = 'freemarker-wrapper'
 
 runtime {
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+
+    targetPlatform("win") {
+        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_windows_hotspot_11.0.13_8.zip")
+    }
+
+    targetPlatform("lin") {
+        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz") {
+            archiveExtension = "tar.gz"
+            pathToHome = "jdk-11.0.13+8"
+            overwrite = true
+        }
+    }
+
+    targetPlatform("mac") {
+        jdkHome = jdkDownload("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.13_8.tar.gz") {
+            archiveExtension = "tar.gz"
+            pathToHome = "jdk-11.0.13+8/Contents/Home"
+            overwrite = true
+        }
+    }
 }
 
 jar {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- To run hamlet on osx locally we need to provide a binary of java compiled of OSX instead of linux
- Adds targetPlatforms for win, lin and mac that link to adoptium JDks
- Updates current dependencies to align with latest available versions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Tried out the current build on my local macOS machine and it failed. A bit of a google around found that the badass plugin for packaging supports generating mulitplatform builds 
https://badass-runtime-plugin.beryx.org/releases/latest/#_methods 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Some testing locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

