### PR TITLE
refactor: only split paramters on first =

### DIFF
--- a/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/RunFreeMarker.java
+++ b/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/RunFreeMarker.java
@@ -79,11 +79,9 @@ public class RunFreeMarker {
 
             Option variablesOption = new Option("v", true, "variables for freemarker template.");
             variablesOption.setArgs(Option.UNLIMITED_VALUES);
-            variablesOption.setValueSeparator('=');
 
             Option rawVariablesOption = new Option("r", true, "raw variables for freemarker template.");
             rawVariablesOption.setArgs(Option.UNLIMITED_VALUES);
-            rawVariablesOption.setValueSeparator('=');
 
             Option outputOption = new Option("o", true, "output file.");
 
@@ -163,14 +161,12 @@ public class RunFreeMarker {
                 if (opt.equals(inputOption.getOpt())) {
                     templateFileName = option.getValue();
                 } else if (opt.equals(variablesOption.getOpt())) {
-                    for (int i = 0; i < values.length; i++) {
-                        input.put(values[i], values[i + 1]);
-                        i++;
+                    for ( String variable: values) {
+                        input.put(variable.split("=", 2)[0], variable.split("=", 2)[1]);
                     }
                 } else if (opt.equals(rawVariablesOption.getOpt())) {
-                    for (int i = 0; i < values.length; i++) {
-                        rawInput.put(values[i], values[i + 1]);
-                        i++;
+                    for ( String rawVariable: values) {
+                        rawInput.put(rawVariable.split("=", 2)[0], rawVariable.split("=", 2)[1]);
                     }
                 } else if (opt.equals(outputOption.getOpt())) {
                     outputFileName = option.getValue();
@@ -310,4 +306,3 @@ public class RunFreeMarker {
     }
 
 }
-


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Updates variable handling for raw and standard variables to only split parameters on the first = and treat any others as value content

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for more complex variable values like base64 encoded strings to be provided as a raw or standard variables. When passing them at the moment the following apache commons cli bug was being hit ( https://issues.apache.org/jira/projects/CLI/issues/CLI-313?filter=allopenissues ) 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

