### PR TITLE
feat: OS based images for bundled jar

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -224,7 +224,7 @@ jobs:
           images: ghcr.io/${{github.repository}}
           flavor: |
             latest=auto
-            suffix=Linux,onlatest=true
+            suffix=Windows,onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=edge,branch=master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -103,22 +103,27 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: jar-file
-          path: ./
+          path: freemarker-wrapper/build/libs/
 
       - name: get bundle
         uses: actions/download-artifact@v2
         with:
           name: engine-bundle
-          path: ./image/
+          path: freemarker-wrapper/build/image/
 
       - name: get build details
         uses: actions/download-artifact@v2
         with:
           name: build-details
-          path: ./.hamlet/
+          path: .hamlet/
 
-      - name: docker meta details
-        id: meta
+      - id: find_wrapper_file
+        name: find_wrapper_file
+        run: |
+          echo ::set-output NAME=WRAPPER_FILE_NAME::$(ls | grep freemarker-wrapper*.jar)
+
+      - name: base meta
+        id: base_meta
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{github.repository}}
@@ -129,18 +134,109 @@ jobs:
             type=edge,branch=master
             type=sha
 
-      - id: find_wrapper_file
-        name: find_wrapper_file
-        run: |
-          echo ::set-output NAME=WRAPPER_FILE_NAME::$(ls | grep freemarker-wrapper*.jar)
-
-      - name: build and push container
+      - name: base push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/*') || github.ref == 'refs/heads/master' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.base_meta.outputs.tags }}
+          labels: ${{ steps.base_meta.outputs.labels }}
           target: base_package
+          build-args: |
+            wrapper_file_name=${{steps.find_wrapper_file.outputs.WRAPPER_FILE_NAME}}
+
+      - name: jar meta
+        id: jar_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=auto
+            suffix=jar,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge,branch=master
+            type=sha
+
+      - name: jar push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/*') || github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.jar_meta.outputs.tags }}
+          labels: ${{ steps.jar_meta.outputs.labels }}
+          target: jar
+          build-args: |
+            wrapper_file_name=${{steps.find_wrapper_file.outputs.WRAPPER_FILE_NAME}}
+
+      - name: Darwin meta
+        id: Darwin_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=auto
+            suffix=Darwin,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge,branch=master
+            type=sha
+
+      - name: Darwin push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/*') || github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.Darwin_meta.outputs.tags }}
+          labels: ${{ steps.Darwin_meta.outputs.labels }}
+          target: Darwin
+          build-args: |
+            wrapper_file_name=${{steps.find_wrapper_file.outputs.WRAPPER_FILE_NAME}}
+
+      - name: Linux meta
+        id: Linux_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=auto
+            suffix=Linux,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge,branch=master
+            type=sha
+
+      - name: Linux push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/*') || github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.Linux_meta.outputs.tags }}
+          labels: ${{ steps.Linux_meta.outputs.labels }}
+          target: Linux
+          build-args: |
+            wrapper_file_name=${{steps.find_wrapper_file.outputs.WRAPPER_FILE_NAME}}
+
+      - name: Windows meta
+        id: Windows_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=auto
+            suffix=Linux,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge,branch=master
+            type=sha
+
+      - name: Windows push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/*') || github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.Windows_meta.outputs.tags }}
+          labels: ${{ steps.Windows_meta.outputs.labels }}
+          target: Windows
           build-args: |
             wrapper_file_name=${{steps.find_wrapper_file.outputs.WRAPPER_FILE_NAME}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,30 @@
-FROM scratch as base_package
+FROM scratch as full_package
 
 ARG wrapper_file_name=freemarker-wrapper-0.0.0.jar
 
 COPY .hamlet/ .hamlet/
-COPY image /image/
-COPY ${wrapper_file_name} /freemarker-wrapper.jar
+COPY freemarker-wrapper/build/image /image/
+COPY freemarker-wrapper/build/libs/${wrapper_file_name} /freemarker-wrapper.jar
+
+FROM scratch as jar
+
+COPY .hamlet/ .hamlet/
+COPY freemarker-wrapper/build/libs/${wrapper_file_name} /freemarker-wrapper.jar
+
+FROM scratch as Darwin
+
+COPY --from=full_package .hamlet/ .hamlet/
+COPY --from=full_package freemarker-wrapper.jar /freemarker-wrapper.jar
+COPY --from=full_package image/freemarker-wrapper-Darwin/ image/freemarker-wrapper-Darwin/
+
+FROM scratch as Linux
+
+COPY --from=full_package .hamlet/ .hamlet/
+COPY --from=full_package freemarker-wrapper.jar /freemarker-wrapper.jar
+COPY --from=full_package image/freemarker-wrapper-Linux/ image/freemarker-wrapper-Linux/
+
+FROM scratch as Windows
+
+COPY --from=full_package .hamlet/ .hamlet/
+COPY --from=full_package freemarker-wrapper.jar /freemarker-wrapper.jar
+COPY --from=full_package image/freemarker-wrapper-Windows/ image/freemarker-wrapper-Darwin/


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a OS specific image for each of the bundled installs
- Alings the docker image with the repository structure to allow for local builds of the container

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Reduce size of container used by the hamlet engine to implement the engine core wrapper

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

