### PR TITLE
fix: handle options with empty values

### DIFF
--- a/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/RunFreeMarker.java
+++ b/freemarker-wrapper/src/main/java/io/hamlet/freemarkerwrapper/RunFreeMarker.java
@@ -162,11 +162,17 @@ public class RunFreeMarker {
                     templateFileName = option.getValue();
                 } else if (opt.equals(variablesOption.getOpt())) {
                     for ( String variable: values) {
-                        input.put(variable.split("=", 2)[0], variable.split("=", 2)[1]);
+                        input.put(
+                            variable.split("=", 2)[0],
+                            variable.split("=", 2).length == 2 ? variable.split("=", 2)[1] : ""
+                        );
                     }
                 } else if (opt.equals(rawVariablesOption.getOpt())) {
                     for ( String rawVariable: values) {
-                        rawInput.put(rawVariable.split("=", 2)[0], rawVariable.split("=", 2)[1]);
+                        rawInput.put(
+                            rawVariable.split("=", 2)[0],
+                            rawVariable.split("=", 2).length == 2 ? rawVariable.split("=", 2)[1] : ""
+                        );
                     }
                 } else if (opt.equals(outputOption.getOpt())) {
                     outputFileName = option.getValue();


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- in some cases when passing options to the wrapper the variable can be empty. This ensures that the empty value is handled properly

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Freemarker wrapper was failing within an invalid index from splitting the value

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

